### PR TITLE
Implement basic bike rev simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# bike-rev-simulator
+# Bike Rev Simulator
+
+This is a simple browser-based bike engine simulator. Open `index.html` in a
+browser to try it out. Use the vertical throttle slider and gear buttons to
+rev the engine and shift gears. The dashboard shows current RPM, speed, and
+gear.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bike Rev Simulator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Bike Rev Simulator</h1>
+    <div class="dashboard">
+        <div>RPM: <span id="rpm">1000</span></div>
+        <div>Speed: <span id="speed">0</span> km/h</div>
+        <div>Gear: <span id="gear">1</span></div>
+    </div>
+    <div class="controls">
+        <label for="throttle">Throttle</label>
+        <input type="range" id="throttle" min="0" max="100" value="0" orient="vertical">
+        <div class="gear-buttons">
+            <button id="gear-down">Gear -</button>
+            <button id="gear-up">Gear +</button>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,68 @@
+const maxRPM = 12000;
+const idleRPM = 1000;
+const ratios = {
+  1: 0.005833,
+  2: 0.009167,
+  3: 0.013333,
+  4: 0.0175,
+  5: 0.021667,
+  6: 0.025
+};
+const accelFactor = 0.5;
+const drag = 0.02;
+
+let gear = 1;
+let speed = 0; // km/h
+let rpm = idleRPM;
+let throttle = document.getElementById('throttle');
+
+const rpmSpan = document.getElementById('rpm');
+const speedSpan = document.getElementById('speed');
+const gearSpan = document.getElementById('gear');
+
+document.getElementById('gear-up').addEventListener('click', () => {
+  if (gear < 6) gear++;
+  gearSpan.textContent = gear;
+});
+
+document.getElementById('gear-down').addEventListener('click', () => {
+  if (gear > 1) gear--;
+  gearSpan.textContent = gear;
+});
+
+// Setup Web Audio
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const oscillator = audioCtx.createOscillator();
+oscillator.type = 'sawtooth';
+const gainNode = audioCtx.createGain();
+oscillator.connect(gainNode).connect(audioCtx.destination);
+oscillator.start();
+
+audioCtx.resume(); // required for some browsers
+
+function updateAudio() {
+  const freq = 50 + rpm * 0.05; // rough mapping
+  oscillator.frequency.setTargetAtTime(freq, audioCtx.currentTime, 0.05);
+  gainNode.gain.setTargetAtTime(throttle.value / 100, audioCtx.currentTime, 0.05);
+}
+
+function update() {
+  // acceleration
+  const acceleration = (throttle.value / 100) * accelFactor;
+  speed += acceleration;
+  speed -= speed * drag;
+  if (speed < 0) speed = 0;
+
+  rpm = speed / ratios[gear];
+  if (rpm < idleRPM && speed === 0 && throttle.value == 0) rpm = idleRPM;
+  if (rpm > maxRPM) {
+    rpm = maxRPM;
+    speed = rpm * ratios[gear]; // hold at rev limiter
+  }
+
+  rpmSpan.textContent = Math.round(rpm);
+  speedSpan.textContent = Math.round(speed);
+  updateAudio();
+}
+
+setInterval(update, 50);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    background: #222;
+    color: #eee;
+}
+.dashboard {
+    margin: 20px auto;
+    padding: 10px;
+    border: 1px solid #555;
+    display: inline-block;
+}
+.controls {
+    margin-top: 20px;
+}
+input[type=range][orient="vertical"] {
+    writing-mode: bt-lr; /* bottom to top */
+    -webkit-appearance: slider-vertical;
+    width: 8px;
+    height: 200px;
+    padding: 0 5px;
+}
+.gear-buttons {
+    margin-top: 10px;
+}
+.gear-buttons button {
+    margin: 0 5px;
+}


### PR DESCRIPTION
## Summary
- add initial interface with throttle, gear controls, and dashboard
- implement simple engine/gear logic with Web Audio API
- style the dashboard and slider controls
- describe usage in README

## Testing
- `npm test` *(fails: no `package.json` found)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bcc068b8483208e1578cb695b18ae